### PR TITLE
fix: keep PreviewFrame mounted to prevent iframe reload on tab switch

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -76,11 +76,11 @@ export function MainContent({ user, project }: MainContentProps) {
 
                 {/* Content Area */}
                 <div className="flex-1 overflow-hidden bg-neutral-50">
-                  {activeView === "preview" ? (
-                    <div className="h-full bg-white">
-                      <PreviewFrame />
-                    </div>
-                  ) : (
+                  {/* Always keep PreviewFrame mounted to avoid iframe reload on tab switch */}
+                  <div className={`h-full bg-white ${activeView === "preview" ? "" : "hidden"}`}>
+                    <PreviewFrame />
+                  </div>
+                  {activeView === "code" && (
                     <ResizablePanelGroup
                       direction="horizontal"
                       className="h-full"


### PR DESCRIPTION
Fix the preview/code toggle button bug where the preview iframe was being destroyed and recreated on every tab switch.

Keep PreviewFrame always mounted using CSS hidden class instead of conditional rendering, so switching back to preview is instant with no reload.

Closes #2

Generated with [Claude Code](https://claude.ai/code)